### PR TITLE
fix: list overlap

### DIFF
--- a/components/content/inspira/ui/animated-list/AnimatedList.vue
+++ b/components/content/inspira/ui/animated-list/AnimatedList.vue
@@ -66,7 +66,7 @@ function getInitial(idx: number) {
         scale: 0,
         opacity: 0,
       }
-    : null; // Only animate the newly added item
+    : undefined; // Only animate the newly added item
 }
 
 // Get enter animation (only the latest item animates in)
@@ -75,14 +75,14 @@ function getEnter(idx: number) {
     ? {
         scale: 1,
         opacity: 1,
-        originY: 0,
+        y: 0,
         transition: {
           type: "spring",
-          stiffness: 350,
+          stiffness: 250,
           damping: 40,
         },
       }
-    : null; // Only animate the newly added item
+    : undefined; // Only animate the newly added item
 }
 
 // Get leave animation (same for all)
@@ -90,6 +90,7 @@ function getLeave() {
   return {
     scale: 0,
     opacity: 0,
+    y: 0,
     transition: {
       type: "spring",
       stiffness: 350,
@@ -103,6 +104,6 @@ function getLeave() {
 <style scoped>
 /* This class is added by transition-group when items move */
 .move {
-  transition: transform 0.4s ease-in-out;
+  transition: transform 0.4s ease-out;
 }
 </style>

--- a/components/content/inspira/ui/animated-list/AnimatedList.vue
+++ b/components/content/inspira/ui/animated-list/AnimatedList.vue
@@ -66,7 +66,7 @@ function getInitial(idx: number) {
         scale: 0,
         opacity: 0,
       }
-    : undefined; // Only animate the newly added item
+    : null; // Only animate the newly added item
 }
 
 // Get enter animation (only the latest item animates in)

--- a/components/content/inspira/ui/animated-list/AnimatedList.vue
+++ b/components/content/inspira/ui/animated-list/AnimatedList.vue
@@ -66,7 +66,7 @@ function getInitial(idx: number) {
         scale: 0,
         opacity: 0,
       }
-    : null; // Only animate the newly added item
+    : undefined; // Only animate the newly added item
 }
 
 // Get enter animation (only the latest item animates in)


### PR DESCRIPTION
This pull request is intended to do two things namely:

1. Fix the type error that occurs when the `initial` and `enter` directives are set to `null` instead of `undefined`. It throws this error: `Type 'null' is not assignable to type 'Variant | undefined'.`
2. Fix the list overlapping over the other list as it is animating in, this pull request intends to fix that by changing:
- The transition property from `ease-in-out` to `ease-out`.
- The `stiffness` from `350` to `250`.
-  The `originY` property to `y`.