### PR TITLE
fix: remove TransitionGroup unavailable prop mode

### DIFF
--- a/components/content/inspira/ui/logo-origami/LogoOrigami.vue
+++ b/components/content/inspira/ui/logo-origami/LogoOrigami.vue
@@ -35,7 +35,7 @@
       <component :is="children[activeIndex % children.length]" />
     </div>
 
-    <TransitionGroup mode="'out-in'">
+    <TransitionGroup>
       <!-- Upper part of the flip -->
       <div
         :key="activeIndex"


### PR DESCRIPTION
TransitionGroup does not take 'mode' prop

```ts
export type TransitionGroupProps = Omit<TransitionProps, 'mode'> & {
    tag?: string;
    moveClass?: string;
};
```