### PR TITLE
Improve and clean Ripple component

### DIFF
--- a/components/content/inspira/examples/ripple/RippleDemo.vue
+++ b/components/content/inspira/examples/ripple/RippleDemo.vue
@@ -7,6 +7,9 @@
     >
       Ripple
     </p>
-    <Ripple />
+    <Ripple
+      class="bg-white/5 [mask-image:linear-gradient(to_bottom,white,transparent)]"
+      circle-class="border-[hsl(var(--primary))] bg-[#0000]/25 dark:bg-[#fff]/25"
+    />
   </div>
 </template>

--- a/components/content/inspira/examples/ripple/RippleDemoBlobed.vue
+++ b/components/content/inspira/examples/ripple/RippleDemoBlobed.vue
@@ -5,11 +5,18 @@
     <p
       class="z-10 whitespace-pre-wrap text-center text-5xl font-medium tracking-tighter text-black dark:text-white"
     >
-      Ripple
+      Blobs
     </p>
+    <small>Are awesome</small>
     <Ripple
       class="bg-white/5 [mask-image:linear-gradient(to_bottom,white,transparent)]"
-      circle-class="border-[hsl(var(--primary))] bg-[#0000]/25 dark:bg-[#fff]/25 rounded-full"
+      circle-class="border-[hsl(var(--primary))] bg-primary/25 blobed"
     />
   </div>
 </template>
+
+<style scoped>
+:deep(.blobed) {
+  border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
+}
+</style>

--- a/components/content/inspira/examples/ripple/RippleDemoLinesOnly.vue
+++ b/components/content/inspira/examples/ripple/RippleDemoLinesOnly.vue
@@ -5,8 +5,9 @@
     <p
       class="z-10 whitespace-pre-wrap text-center text-5xl font-medium tracking-tighter text-black dark:text-white"
     >
-      Lines only
+      Lines
     </p>
-    <Ripple circle-class="border-[hsl(var(--primary))]" />
+    <small>Only</small>
+    <Ripple circle-class="border-[hsl(var(--primary))] rounded-full" />
   </div>
 </template>

--- a/components/content/inspira/examples/ripple/RippleDemoLinesOnly.vue
+++ b/components/content/inspira/examples/ripple/RippleDemoLinesOnly.vue
@@ -1,0 +1,12 @@
+<template>
+  <div
+    class="relative flex h-[450px] w-full flex-col items-center justify-center overflow-hidden lg:w-full md:w-full"
+  >
+    <p
+      class="z-10 whitespace-pre-wrap text-center text-5xl font-medium tracking-tighter text-black dark:text-white"
+    >
+      Lines only
+    </p>
+    <Ripple circle-class="border-[hsl(var(--primary))]" />
+  </div>
+</template>

--- a/components/content/inspira/examples/ripple/RippleDemoSquared.vue
+++ b/components/content/inspira/examples/ripple/RippleDemoSquared.vue
@@ -5,11 +5,11 @@
     <p
       class="z-10 whitespace-pre-wrap text-center text-5xl font-medium tracking-tighter text-black dark:text-white"
     >
-      Ripple
+      Squared
     </p>
     <Ripple
       class="bg-white/5 [mask-image:linear-gradient(to_bottom,white,transparent)]"
-      circle-class="border-[hsl(var(--primary))] bg-[#0000]/25 dark:bg-[#fff]/25 rounded-full"
+      circle-class="border-[hsl(var(--primary))] bg-[#0000]/25 dark:bg-[#fff]/25 rounded-md"
     />
   </div>
 </template>

--- a/components/content/inspira/ui/ripple/Ripple.vue
+++ b/components/content/inspira/ui/ripple/Ripple.vue
@@ -1,72 +1,34 @@
 <template>
-  <div
-    :class="
-      cn(
-        'absolute inset-0 bg-white/5 [mask-image:linear-gradient(to_bottom,white,transparent)]',
-        props.class,
-      )
-    "
-  >
-    <div
-      v-for="(_, i) in numberOfCircles"
-      :key="i"
-    >
-      <div
-        :key="i"
-        :class="
-          cn('absolute rounded-full bg-[#0000]/25 dark:bg-[#fff]/25 shadow-xl', 'animate-ripple')
-        "
-        :style="{
-          width: `${props.circleSize + i * 70}px`,
-          height: `${props.circleSize + i * 70}px`,
-          opacity: props.circleOpacity - i * 0.03,
-          animationDelay: `${i * 0.06}s`,
-          borderStyle: i === props.count - 1 ? 'dashed' : 'solid',
-          borderWidth: '1px',
-          borderColor: `hsl(var(--foreground), ${5 + (i * 5) / 100})`,
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%) scale(1)',
-        }"
-      />
-    </div>
+  <div class="absolute inset-0">
+    <RippleCircle
+      v-for="index in numberOfCircles"
+      :key="index"
+      :opacity="baseCircleOpacity - index * circleOpacityDowngradeRatio"
+      :size="baseCircleSize + index * spaceBetweenCircle"
+      :animation-delay="index * waveSpeed"
+      :border-style="index === numberOfCircles - 1 ? 'dashed' : 'solid'"
+      :class="circleClass"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { cn } from "@/lib/utils";
-
-interface RippleProps {
-  circleSize?: number;
-  circleOpacity?: number;
-  count?: number;
-  class?: string;
+interface Props {
+  baseCircleSize?: number;
+  baseCircleOpacity?: number;
+  spaceBetweenCircle?: number;
+  circleOpacityDowngradeRatio?: number;
+  circleClass?: string;
+  waveSpeed?: number;
+  numberOfCircles?: number;
 }
 
-const props = withDefaults(defineProps<RippleProps>(), {
-  circleSize: 210,
-  circleOpacity: 0.24,
-  count: 8,
-});
-
-const numberOfCircles = computed(() => {
-  return Array.from({ length: props.count });
+withDefaults(defineProps<Props>(), {
+  baseCircleSize: 210,
+  baseCircleOpacity: 0.24,
+  circleOpacityDowngradeRatio: 0.03,
+  waveSpeed: 80,
+  spaceBetweenCircle: 70,
+  numberOfCircles: 7,
 });
 </script>
-
-<style scoped>
-.animate-ripple {
-  animation: ripple-effect var(--duration, 2s) ease-in-out calc(var(--i, 0) * 0.2s) infinite;
-}
-
-@keyframes ripple-effect {
-  0%,
-  100% {
-    transform: translate(-50%, -50%) scale(1);
-  }
-
-  50% {
-    transform: translate(-50%, -50%) scale(0.9);
-  }
-}
-</style>

--- a/components/content/inspira/ui/ripple/RippleCircle.vue
+++ b/components/content/inspira/ui/ripple/RippleCircle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="cn('absolute rounded-full shadow-xl', 'animate-ripple-circle', props.class)" />
+  <div :class="cn('absolute shadow-xl', 'animate-ripple-circle', props.class)" />
 </template>
 
 <script setup lang="ts">

--- a/components/content/inspira/ui/ripple/RippleCircle.vue
+++ b/components/content/inspira/ui/ripple/RippleCircle.vue
@@ -1,0 +1,46 @@
+<template>
+  <div :class="cn('absolute rounded-full shadow-xl', 'animate-ripple-circle', props.class)" />
+</template>
+
+<script setup lang="ts">
+import { cn } from "@/lib/utils";
+
+interface Props {
+  size?: number;
+  class?: string;
+  opacity?: number;
+  animationDelay?: number;
+  borderStyle?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 210,
+  opacity: 0.24,
+});
+</script>
+
+<style scoped>
+.animate-ripple-circle {
+  animation: ripple-effect var(--duration, 2s) ease-in-out calc(var(--i, 0) * 0.2s) infinite;
+  border-width: 1px;
+  top: 50%;
+  left: 50%;
+  width: v-bind('props.size + "px"');
+  height: v-bind('props.size + "px"');
+  animation-delay: v-bind('props.animationDelay + "ms"');
+  opacity: v-bind("props.opacity");
+  transform: translate(-50%, -50%) scale(1);
+  border-style: v-bind("props.borderStyle");
+}
+
+@keyframes ripple-effect {
+  0%,
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  50% {
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+</style>

--- a/components/content/inspira/ui/ripple/RippleContainer.vue
+++ b/components/content/inspira/ui/ripple/RippleContainer.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="relative">
+    <slot />
+    <Ripple />
+  </div>
+</template>

--- a/content/2.components/lens.md
+++ b/content/2.components/lens.md
@@ -25,13 +25,13 @@ Lens are static in center
 
 ## API
 
-| Prop Name | Type     | Default | Description                                                     |
-| --------- | -------- | ------- | --------------------------------------------------------------- |
-| `zoomFactor`   | `number` |   `1.5`   | The magnification factor for the lens.               |
-| `lensSize` | `number` |  `170` | The diameter of the lens in pixels. |
-| `position` | `{ x: number, y: number }` | `{ x: 200, y: 150 }` | The static position of the lens (when isStatic is true). |
-| `isStatic` | `boolean` | `false` | If true, the lens stays in a fixed position; if false, it follows the mouse. |
-| `hovering` | `boolean` | `"false"` | External control for the hover state. |
+| Prop Name    | Type                       | Default              | Description                                                                  |
+| ------------ | -------------------------- | -------------------- | ---------------------------------------------------------------------------- |
+| `zoomFactor` | `number`                   | `1.5`                | The magnification factor for the lens.                                       |
+| `lensSize`   | `number`                   | `170`                | The diameter of the lens in pixels.                                          |
+| `position`   | `{ x: number, y: number }` | `{ x: 200, y: 150 }` | The static position of the lens (when isStatic is true).                     |
+| `isStatic`   | `boolean`                  | `false`              | If true, the lens stays in a fixed position; if false, it follows the mouse. |
+| `hovering`   | `boolean`                  | `"false"`            | External control for the hover state.                                        |
 
 ## Component Code
 

--- a/content/2.components/ripple.md
+++ b/content/2.components/ripple.md
@@ -2,33 +2,51 @@
 title: Ripple
 description: An animated ripple effect typically used behind elements to emphasize them.
 navBadges:
-  - value: New
-    type: lime
+  - value: Updated
+    type: info
 ---
 
 ::ComponentLoader{label="Preview" componentName="RippleDemo" type="examples" id="ripple"}
 ::
 
+## Examples
+
+Only lines
+
+::ComponentLoader{label="Preview" componentName="RippleDemoLinesOnly" type="examples" id="ripple"}
+::
+
 ## API
 
-| Prop Name       | Type     | Default | Description                             |
-| --------------- | -------- | ------- | --------------------------------------- |
-| `circleSize`    | `number` | `210`   | The size of the main circle in pixels.  |
-| `circleOpacity` | `number` | `0.24`  | The opacity of the main circle.         |
-| `count`         | `number` | `8`     | The number of ripple circles to render. |
+| Prop Name                     | Type     | Default     | Description                                                            |
+| ----------------------------- | -------- | ----------- | ---------------------------------------------------------------------- |
+| `baseCircleSize`              | `number` | `210`       | The size of the main circle in pixels.                                 |
+| `baseCircleOpacity`           | `number` | `0.24`      | The opacity of the main circle.                                        |
+| `spaceBetweenCircle`          | `number` | `70`        | The space between each ripple circle in pixels.                        |
+| `circleOpacityDowngradeRatio` | `number` | `0.03`      | The rate at which opacity decreases for each successive ripple circle. |
+| `circleClass`                 | `string` | `undefined` | CSS class name(s) for additional styling of circles.                   |
+| `waveSpeed`                   | `number` | `80`        | The animation speed for the wave effect, measured in ms.               |
+| `numberOfCircles`             | `number` | `7`         | The number of ripple circles to render.                                |
 
 ## Component Code
 
-You can copy and paste the following code to create these components:
+You can copy and paste the following code to create this component:
 
-::CodeViewer{filename="Ripple.vue" language="vue" componentName="Ripple" type="ui" id="ripple"}
+::code-group
+
+::CodeViewerTab{filename="Ripple.vue" language="vue" componentName="Ripple" type="ui" id="ripple"}
 ::
 
-## Features
+::CodeViewerTab{filename="RippleCircle.vue" language="vue" componentName="RippleCircle" type="ui" id="ripple"}
+::
 
-- **Slot Support**: Easily add any content inside the component using the default slot.
+::CodeViewerTab{filename="RippleContainer.vue" language="vue" componentName="RippleContainer" type="ui" id="ripple"}
+::
+
+::
 
 ## Credits
 
 - Credits to [Magic UI](https://magicui.design/docs/components/ripple).
 - Credits to [SivaReddy Uppathi](https://github.com/sivareddyuppathi) for porting this component.
+- Credits to [Nathan De Pachtere](https://nathandepachtere.com/) for updating this component.

--- a/content/2.components/ripple.md
+++ b/content/2.components/ripple.md
@@ -16,6 +16,16 @@ Only lines
 ::ComponentLoader{label="Preview" componentName="RippleDemoLinesOnly" type="examples" id="ripple"}
 ::
 
+Squared
+
+::ComponentLoader{label="Preview" componentName="RippleDemoSquared" type="examples" id="ripple"}
+::
+
+Blobed
+
+::ComponentLoader{label="Preview" componentName="RippleDemoBlobed" type="examples" id="ripple"}
+::
+
 ## API
 
 | Prop Name                     | Type     | Default     | Description                                                            |

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -114,7 +114,7 @@ export default {
         "collapsible-up": {
           from: { height: "var(--radix-collapsible-content-height)" },
           to: { height: "0" },
-        }
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",


### PR DESCRIPTION
- Remove inline CSS styles
- Add `props` to configure behavior
- Add `RippleContainer` for lazy developers
- Move classes to props in order to make them configurable
- Remove useless `<div>`
- Convert `second` to `ms`