### PR TITLE
fix(homepage examples): Fixed corners overflowing rounded borders

### DIFF
--- a/components/content/common/HomePageExamples.vue
+++ b/components/content/common/HomePageExamples.vue
@@ -1,39 +1,56 @@
 <template>
   <div class="my-16 mt-24 flex flex-col items-center justify-center">
-    <BlurReveal :delay="0" :duration="1">
+    <BlurReveal
+      :delay="0"
+      :duration="1"
+    >
       <div class="text-5xl font-semibold">Check out some examples!</div>
     </BlurReveal>
   </div>
-  <div class="flex w-full max-w-7xl flex-col flex-wrap items-center justify-center gap-4 p-4 lg:flex-row">
-    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+  <div
+    class="flex w-full max-w-7xl flex-col flex-wrap items-center justify-center gap-4 p-4 lg:flex-row"
+  >
+    <PatternBackground
+      :animate="true"
+      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
       class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow">
+      :speed="PATTERN_BACKGROUND_SPEED.Slow"
+    >
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
+      >
         3D Card Hover Effect
       </h3>
       <CardDemo2 />
     </PatternBackground>
 
-    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+    <PatternBackground
+      :animate="true"
+      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
       class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow">
+      :speed="PATTERN_BACKGROUND_SPEED.Slow"
+    >
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
+      >
         Text Hover Effect
       </h3>
       <p>Hover below to reveal text</p>
       <TextHoverEffectDemo />
     </PatternBackground>
 
-    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+    <PatternBackground
+      :animate="true"
+      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
       class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow">
+      :speed="PATTERN_BACKGROUND_SPEED.Slow"
+    >
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
+      >
         Radiant Text
       </h3>
       <RadiantTextDemo />

--- a/components/content/common/HomePageExamples.vue
+++ b/components/content/common/HomePageExamples.vue
@@ -1,56 +1,39 @@
 <template>
   <div class="my-16 mt-24 flex flex-col items-center justify-center">
-    <BlurReveal
-      :delay="0"
-      :duration="1"
-    >
+    <BlurReveal :delay="0" :duration="1">
       <div class="text-5xl font-semibold">Check out some examples!</div>
     </BlurReveal>
   </div>
-  <div
-    class="flex w-full max-w-7xl flex-col flex-wrap items-center justify-center gap-4 p-4 lg:flex-row"
-  >
-    <PatternBackground
-      :animate="true"
-      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+  <div class="flex w-full max-w-7xl flex-col flex-wrap items-center justify-center gap-4 p-4 lg:flex-row">
+    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
-      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow"
-    >
+      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
+      :speed="PATTERN_BACKGROUND_SPEED.Slow">
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
-      >
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
         3D Card Hover Effect
       </h3>
       <CardDemo2 />
     </PatternBackground>
 
-    <PatternBackground
-      :animate="true"
-      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
-      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow"
-    >
+      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
+      :speed="PATTERN_BACKGROUND_SPEED.Slow">
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
-      >
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
         Text Hover Effect
       </h3>
       <p>Hover below to reveal text</p>
       <TextHoverEffectDemo />
     </PatternBackground>
 
-    <PatternBackground
-      :animate="true"
-      :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
+    <PatternBackground :animate="true" :direction="PATTERN_BACKGROUND_DIRECTION.TopRight"
       :variant="PATTERN_BACKGROUND_VARIANT.Dot"
-      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8"
-      :speed="PATTERN_BACKGROUND_SPEED.Slow"
-    >
+      class="flex h-fit w-full flex-col items-center gap-4 rounded-lg border px-4 py-8 overflow-hidden"
+      :speed="PATTERN_BACKGROUND_SPEED.Slow">
       <h3
-        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent"
-      >
+        class="relative z-20 bg-gradient-to-b from-neutral-200 to-neutral-500 bg-clip-text py-8 text-3xl font-bold text-transparent">
         Radiant Text
       </h3>
       <RadiantTextDemo />


### PR DESCRIPTION
**What was wrong?**
Examples were overflowing their container on the frontpage

![image](https://github.com/user-attachments/assets/7312ad0e-8ce6-46b4-8800-1ec540dd50c4)

**What was the fix?**
I've added overflow hidden on the example's container