### PR TITLE
fix: Morphing Text animation on Firefox

### DIFF
--- a/components/content/inspira/ui/morphing-text/MorphingText.vue
+++ b/components/content/inspira/ui/morphing-text/MorphingText.vue
@@ -18,7 +18,7 @@
 
     <svg
       id="filters"
-      class="hidden size-full"
+      class="fixed size-0"
       preserveAspectRatio="xMidYMid slice"
     >
       <defs>


### PR DESCRIPTION
Changed the `class` attribute of the SVG element with ID `filters` from `hidden size-full` to `fixed size-0`.

As a result, the Morphing animation now works as expected in Firefox.

Closing #87.