### PR TITLE
refactor: add ESLint rule for Vue block order

### DIFF
--- a/components/content/inspira/examples/AnimatedTooltipDemo.vue
+++ b/components/content/inspira/examples/AnimatedTooltipDemo.vue
@@ -1,3 +1,9 @@
+<template>
+  <div class="mb-10 flex min-h-96 w-full flex-row items-center justify-center">
+    <AnimatedTooltip :items="people" />
+  </div>
+</template>
+
 <script setup lang="ts">
 const people = [
   {
@@ -44,9 +50,3 @@ const people = [
   },
 ];
 </script>
-
-<template>
-  <div class="mb-10 flex min-h-96 w-full flex-row items-center justify-center">
-    <AnimatedTooltip :items="people" />
-  </div>
-</template>

--- a/components/content/inspira/examples/OrbitDemo.vue
+++ b/components/content/inspira/examples/OrbitDemo.vue
@@ -1,7 +1,3 @@
-<script setup lang="ts">
-import { ORBIT_DIRECTION } from "../ui/orbit";
-</script>
-
 <template>
   <div
     class="relative flex h-[500px] w-full flex-col items-center justify-center overflow-hidden rounded-lg border bg-background md:shadow-xl"
@@ -56,3 +52,7 @@ import { ORBIT_DIRECTION } from "../ui/orbit";
     </Orbit>
   </div>
 </template>
+
+<script setup lang="ts">
+import { ORBIT_DIRECTION } from "../ui/orbit";
+</script>

--- a/components/content/inspira/examples/OrbitDemoSynchronized.vue
+++ b/components/content/inspira/examples/OrbitDemoSynchronized.vue
@@ -1,18 +1,3 @@
-<script setup lang="ts">
-import { ORBIT_DIRECTION, type OrbitDirection } from "../ui/orbit";
-
-const direction = ref<OrbitDirection>(ORBIT_DIRECTION.Clockwise);
-
-function switchDirection() {
-  if (ORBIT_DIRECTION.Clockwise === direction.value) {
-    direction.value = ORBIT_DIRECTION.CounterClockwise;
-    return;
-  }
-
-  direction.value = ORBIT_DIRECTION.Clockwise;
-}
-</script>
-
 <template>
   <div class="flex w-full flex-row items-center justify-between py-4">
     <p>
@@ -59,3 +44,18 @@ function switchDirection() {
     </Orbit>
   </div>
 </template>
+
+<script setup lang="ts">
+import { ORBIT_DIRECTION, type OrbitDirection } from "../ui/orbit";
+
+const direction = ref<OrbitDirection>(ORBIT_DIRECTION.Clockwise);
+
+function switchDirection() {
+  if (ORBIT_DIRECTION.Clockwise === direction.value) {
+    direction.value = ORBIT_DIRECTION.CounterClockwise;
+    return;
+  }
+
+  direction.value = ORBIT_DIRECTION.Clockwise;
+}
+</script>

--- a/components/content/inspira/ui/animated-tooltip/AnimatedTooltip.vue
+++ b/components/content/inspira/ui/animated-tooltip/AnimatedTooltip.vue
@@ -1,46 +1,3 @@
-<script setup lang="ts">
-interface Item {
-  id: number;
-  name: string;
-  designation: string;
-  image: string;
-}
-
-defineProps<{
-  items: Item[];
-}>();
-
-const hoveredIndex = ref<number | null>(null);
-const mouseX = ref<number>(0);
-
-// Calculate rotation and translation based on mouse position
-const rotation = computed<number>(() => {
-  const x = mouseX.value;
-  return (x / 100) * 50;
-});
-
-const translation = computed<number>(() => {
-  const x = mouseX.value;
-  return (x / 100) * 50;
-});
-
-// Handle initial mouse position and hover
-function handleMouseEnter(event: MouseEvent, itemId: number) {
-  hoveredIndex.value = itemId;
-  // Calculate initial position immediately
-  const rect = (event.target as HTMLElement)?.getBoundingClientRect();
-  const halfWidth = rect.width / 2;
-  mouseX.value = event.clientX - rect.left - halfWidth;
-}
-
-// Handle mouse movement
-function handleMouseMove(event: MouseEvent) {
-  const rect = (event.target as HTMLElement)?.getBoundingClientRect();
-  const halfWidth = rect.width / 2;
-  mouseX.value = event.clientX - rect.left - halfWidth;
-}
-</script>
-
 <template>
   <div
     v-for="item in items"
@@ -100,3 +57,46 @@ function handleMouseMove(event: MouseEvent) {
     />
   </div>
 </template>
+
+<script setup lang="ts">
+interface Item {
+  id: number;
+  name: string;
+  designation: string;
+  image: string;
+}
+
+defineProps<{
+  items: Item[];
+}>();
+
+const hoveredIndex = ref<number | null>(null);
+const mouseX = ref<number>(0);
+
+// Calculate rotation and translation based on mouse position
+const rotation = computed<number>(() => {
+  const x = mouseX.value;
+  return (x / 100) * 50;
+});
+
+const translation = computed<number>(() => {
+  const x = mouseX.value;
+  return (x / 100) * 50;
+});
+
+// Handle initial mouse position and hover
+function handleMouseEnter(event: MouseEvent, itemId: number) {
+  hoveredIndex.value = itemId;
+  // Calculate initial position immediately
+  const rect = (event.target as HTMLElement)?.getBoundingClientRect();
+  const halfWidth = rect.width / 2;
+  mouseX.value = event.clientX - rect.left - halfWidth;
+}
+
+// Handle mouse movement
+function handleMouseMove(event: MouseEvent) {
+  const rect = (event.target as HTMLElement)?.getBoundingClientRect();
+  const halfWidth = rect.width / 2;
+  mouseX.value = event.clientX - rect.left - halfWidth;
+}
+</script>

--- a/components/content/inspira/ui/letter-pullup/LetterPullup.vue
+++ b/components/content/inspira/ui/letter-pullup/LetterPullup.vue
@@ -1,3 +1,27 @@
+<template>
+  <div class="flex justify-center">
+    <div
+      v-for="(letter, index) in letters"
+      :key="letter"
+    >
+      <h1
+        v-motion
+        :initial="pullupVariant.initial"
+        :enter="pullupVariant.enter(index)"
+        :class="
+          cn(
+            'font-display text-center text-4xl font-bold tracking-[-0.02em] text-black drop-shadow-sm md:text-4xl md:leading-[5rem]',
+            props.class,
+          )
+        "
+      >
+        <span v-if="letter === ' '">&nbsp;</span>
+        <span v-else>{{ letter }}</span>
+      </h1>
+    </div>
+  </div>
+</template>
+
 <script setup lang="ts">
 import { cn } from "~/lib/utils";
 
@@ -22,27 +46,3 @@ const pullupVariant = {
   }),
 };
 </script>
-
-<template>
-  <div class="flex justify-center">
-    <div
-      v-for="(letter, index) in letters"
-      :key="letter"
-    >
-      <h1
-        v-motion
-        :initial="pullupVariant.initial"
-        :enter="pullupVariant.enter(index)"
-        :class="
-          cn(
-            'font-display text-center text-4xl font-bold tracking-[-0.02em] text-black drop-shadow-sm md:text-4xl md:leading-[5rem]',
-            props.class,
-          )
-        "
-      >
-        <span v-if="letter === ' '">&nbsp;</span>
-        <span v-else>{{ letter }}</span>
-      </h1>
-    </div>
-  </div>
-</template>

--- a/components/content/inspira/ui/sparkles-text/SparklesText.vue
+++ b/components/content/inspira/ui/sparkles-text/SparklesText.vue
@@ -1,3 +1,49 @@
+<template>
+  <div
+    class="text-6xl font-bold"
+    :class="props.class"
+  >
+    <span class="relative inline-block">
+      <template
+        v-for="sparkle in sparkles"
+        :key="sparkle.id"
+      >
+        <!-- Animated star SVG with fade, scale, and rotation effects -->
+        <svg
+          v-motion="{
+            initial: { opacity: 0, scale: 0, rotate: 75 },
+            enter: {
+              opacity: [0, 1, 0],
+              scale: [0, sparkle.scale, 0],
+              rotate: [75, 120, 150],
+              transition: {
+                duration: 800,
+                repeat: Infinity,
+                delay: sparkle.delay * 1000,
+              },
+            },
+          }"
+          class="pointer-events-none absolute z-20"
+          :style="{
+            left: sparkle.x,
+            top: sparkle.y,
+            opacity: 0,
+          }"
+          width="21"
+          height="21"
+          viewBox="0 0 21 21"
+        >
+          <path
+            d="M9.82531 0.843845C10.0553 0.215178 10.9446 0.215178 11.1746 0.843845L11.8618 2.72026C12.4006 4.19229 12.3916 6.39157 13.5 7.5C14.6084 8.60843 16.8077 8.59935 18.2797 9.13822L20.1561 9.82534C20.7858 10.0553 20.7858 10.9447 20.1561 11.1747L18.2797 11.8618C16.8077 12.4007 14.6084 12.3916 13.5 13.5C12.3916 14.6084 12.4006 16.8077 11.8618 18.2798L11.1746 20.1562C10.9446 20.7858 10.0553 20.7858 9.82531 20.1562L9.13819 18.2798C8.59932 16.8077 8.60843 14.6084 7.5 13.5C6.39157 12.3916 4.19225 12.4007 2.72023 11.8618L0.843814 11.1747C0.215148 10.9447 0.215148 10.0553 0.843814 9.82534L2.72023 9.13822C4.19225 8.59935 6.39157 8.60843 7.5 7.5C8.60843 6.39157 8.59932 4.19229 9.13819 2.72026L9.82531 0.843845Z"
+            :fill="sparkle.color"
+          />
+        </svg>
+      </template>
+      {{ text }}
+    </span>
+  </div>
+</template>
+
 <script setup lang="ts">
 interface Sparkle {
   id: string;
@@ -69,49 +115,3 @@ onUnmounted(() => {
   }
 });
 </script>
-
-<template>
-  <div
-    class="text-6xl font-bold"
-    :class="props.class"
-  >
-    <span class="relative inline-block">
-      <template
-        v-for="sparkle in sparkles"
-        :key="sparkle.id"
-      >
-        <!-- Animated star SVG with fade, scale, and rotation effects -->
-        <svg
-          v-motion="{
-            initial: { opacity: 0, scale: 0, rotate: 75 },
-            enter: {
-              opacity: [0, 1, 0],
-              scale: [0, sparkle.scale, 0],
-              rotate: [75, 120, 150],
-              transition: {
-                duration: 800,
-                repeat: Infinity,
-                delay: sparkle.delay * 1000,
-              },
-            },
-          }"
-          class="pointer-events-none absolute z-20"
-          :style="{
-            left: sparkle.x,
-            top: sparkle.y,
-            opacity: 0,
-          }"
-          width="21"
-          height="21"
-          viewBox="0 0 21 21"
-        >
-          <path
-            d="M9.82531 0.843845C10.0553 0.215178 10.9446 0.215178 11.1746 0.843845L11.8618 2.72026C12.4006 4.19229 12.3916 6.39157 13.5 7.5C14.6084 8.60843 16.8077 8.59935 18.2797 9.13822L20.1561 9.82534C20.7858 10.0553 20.7858 10.9447 20.1561 11.1747L18.2797 11.8618C16.8077 12.4007 14.6084 12.3916 13.5 13.5C12.3916 14.6084 12.4006 16.8077 11.8618 18.2798L11.1746 20.1562C10.9446 20.7858 10.0553 20.7858 9.82531 20.1562L9.13819 18.2798C8.59932 16.8077 8.60843 14.6084 7.5 13.5C6.39157 12.3916 4.19225 12.4007 2.72023 11.8618L0.843814 11.1747C0.215148 10.9447 0.215148 10.0553 0.843814 9.82534L2.72023 9.13822C4.19225 8.59935 6.39157 8.60843 7.5 7.5C8.60843 6.39157 8.59932 4.19229 9.13819 2.72026L9.82531 0.843845Z"
-            :fill="sparkle.color"
-          />
-        </svg>
-      </template>
-      {{ text }}
-    </span>
-  </div>
-</template>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,12 @@ export default withNuxt(
       "func-style": ["error", "declaration"],
       "vue/multi-word-component-names": "off",
       "vue/require-default-prop": "off",
+      "vue/block-order": [
+        "error",
+        {
+          order: ["template", "script", "style"],
+        },
+      ],
       "tailwindcss/no-custom-classname": "off",
       "@typescript-eslint/no-empty-object-type": [
         "error",


### PR DESCRIPTION
This PR introduces a new ESLint rule enforcing the block order for Vue components as specified in the project's style guide. The enforced order is:  
1. `<template>`  
2. `<script>`  
3. `<style>`  

All existing Vue files have been updated to comply with this rule.