### PR TITLE
feat: add Script Copy component, forked from MagicUI

### DIFF
--- a/components/content/inspira/examples/ScriptCopyDemo.vue
+++ b/components/content/inspira/examples/ScriptCopyDemo.vue
@@ -1,0 +1,10 @@
+<template>
+  <ScriptCopy
+    :command-map="{
+      npm: 'npm run shadcn add button',
+      yarn: 'yarn shadcn add button',
+      pnpm: 'pnpm dlx shadcn@latest add button',
+      bun: 'bun x shadcn@latest add button',
+    }"
+  />
+</template>

--- a/components/content/inspira/ui/script-copy/ScriptCopy.vue
+++ b/components/content/inspira/ui/script-copy/ScriptCopy.vue
@@ -1,0 +1,182 @@
+<template>
+  <div :class="cn('mx-auto flex max-w-md items-center justify-center', $props.class)">
+    <div class="w-full space-y-2">
+      <div class="mb-2 flex items-center justify-between">
+        <div
+          v-if="showMultiplePackageOptions"
+          class="relative"
+        >
+          <div class="inline-flex overflow-hidden rounded-sm border border-border text-xs">
+            <div
+              v-for="(pm, index) in packageManagers"
+              :key="pm"
+              class="flex items-center"
+            >
+              <div
+                v-if="index > 0"
+                class="h-4 w-px bg-border"
+                aria-hidden="true"
+              />
+              <button
+                type="button"
+                :class="[
+                  'relative rounded-none bg-background px-2 py-1 hover:bg-background focus:outline-none',
+                  packageManager === pm ? 'text-primary' : 'text-muted-foreground',
+                ]"
+                @click="() => (packageManager = pm)"
+              >
+                {{ pm }}
+                <transition
+                  name="tab-underline"
+                  type="transition"
+                  mode="out-in"
+                >
+                  <div
+                    v-if="packageManager === pm"
+                    class="absolute inset-x-0 bottom-px mx-auto h-0.5 w-[90%] bg-primary"
+                  />
+                </transition>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="relative flex items-center gap-2">
+        <div class="min-w-[300px] grow font-mono">
+          <!-- eslint-disable vue/no-v-html -->
+          <div
+            v-if="highlightedCode"
+            :class="[
+              '[&>pre]:overflow-x-auto [&>pre]:rounded-sm [&>pre]:p-2 [&>pre]:px-4 [&>pre]:font-mono',
+              theme === 'dark' ? 'dark' : 'light',
+            ]"
+            v-html="highlightedCode"
+          />
+          <!--eslint-enable-->
+          <pre
+            v-else
+            class="rounded-sm border border-border bg-white p-2 px-4 font-mono dark:bg-black"
+            >{{ currentCommand }}
+          </pre>
+        </div>
+
+        <button
+          type="button"
+          class="relative grid place-items-center rounded-sm border border-border bg-background p-2 hover:bg-accent focus:outline-none"
+          :aria-label="copied ? 'Copied' : 'Copy to clipboard'"
+          @click="copyToClipboard"
+        >
+          <span class="sr-only">{{ copied ? "Copied" : "Copy" }}</span>
+
+          <transition
+            name="icon-scale"
+            mode="in-out"
+          >
+            <Icon
+              v-if="!copied"
+              name="lucide:copy"
+              size="16"
+            />
+            <Icon
+              v-else
+              name="lucide:check"
+              size="16"
+            />
+          </transition>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { HTMLAttributes } from "vue";
+import { cn } from "~/lib/utils";
+import { codeToHtml } from "shiki";
+
+interface ScriptCopyButtonProps {
+  class?: HTMLAttributes["class"];
+  commandMap: Record<string, string>;
+  showMultiplePackageOptions?: boolean;
+  codeLanguage?: string;
+  lightTheme?: string;
+  darkTheme?: string;
+  theme?: "light" | "dark";
+}
+
+const props = withDefaults(defineProps<ScriptCopyButtonProps>(), {
+  showMultiplePackageOptions: true,
+  theme: "dark",
+  codeLanguage: "shell",
+  lightTheme: "min-light",
+  darkTheme: "min-dark",
+});
+
+const { showMultiplePackageOptions, codeLanguage, lightTheme, darkTheme, commandMap, theme } =
+  toRefs(props);
+
+const packageManagers = Object.keys(commandMap.value);
+const packageManager = ref<string>(packageManagers[0]);
+
+const copied = ref<boolean>(false);
+const highlightedCode = ref<string>("");
+const currentCommand = computed(() => commandMap.value[packageManager.value]);
+
+async function loadHighlightedCode() {
+  try {
+    const highlighted = await codeToHtml(currentCommand.value, {
+      lang: codeLanguage.value,
+      themes: {
+        light: lightTheme.value,
+        dark: darkTheme.value,
+      },
+      defaultColor: theme.value === "dark" ? "dark" : "light",
+    });
+    highlightedCode.value = highlighted;
+  } catch (error) {
+    highlightedCode.value = `<pre>${currentCommand.value}</pre>`;
+  }
+}
+
+function copyToClipboard() {
+  if (!navigator?.clipboard) return;
+  navigator.clipboard.writeText(currentCommand.value);
+  copied.value = true;
+  setTimeout(() => (copied.value = false), 2000);
+}
+
+watch([currentCommand, theme, codeLanguage, lightTheme, darkTheme], loadHighlightedCode, {
+  immediate: true,
+});
+</script>
+
+<style scoped>
+.icon-scale-enter-active,
+.icon-scale-leave-active {
+  transition: transform 0.3s;
+}
+.icon-scale-enter-from,
+.icon-scale-leave-to {
+  transform: scale(0);
+}
+.icon-scale-enter-to,
+.icon-scale-leave-from {
+  transform: scale(1);
+}
+
+.tab-underline-enter-active,
+.tab-underline-leave-active {
+  transition: all 0.2s ease;
+}
+.tab-underline-enter-from,
+.tab-underline-leave-to {
+  opacity: 0;
+  transform: translateY(2px);
+}
+.tab-underline-enter-to,
+.tab-underline-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+</style>

--- a/content/2.components/script-copy.md
+++ b/content/2.components/script-copy.md
@@ -1,0 +1,87 @@
+---
+title: Script Copy
+description: A script copy component that allows users to copy code to clipboard.
+navBadges:
+  - value: New
+    type: lime
+---
+
+::ComponentLoader{label="Preview" componentName="ScriptCopyDemo" type="examples"}
+::
+
+::alert
+**Note:** This component requires `shiki` as a dependency. Please install these using following commands.
+
+    ::code-group
+
+    ```bash [npm]
+    npm install -D shiki
+    ```
+
+    ```bash [yarn]
+    yarn add -D shiki
+    ```
+
+    ```bash [pnpm]
+    pnpm add -D shiki
+    ```
+
+    ```bash [bun]
+    bun add -D shiki
+    ```
+    ::
+
+::
+
+## API
+
+::steps
+
+### `ScriptCopy`
+
+#### Props
+
+| Prop Name                    | Type                    | Default     | Description                                                           |
+| ---------------------------- | ----------------------- | ----------- | --------------------------------------------------------------------- |
+| `class`                      | `string`                | -           | Additional classes for styling the component.                         |
+| `commandMap`                 | `Record<string,string>` | -           | Map of package manager names to their corresponding install commands. |
+| `showMultiplePackageOptions` | `boolean`               | `true`      | Whether to show multiple package manager options.                     |
+| `codeLanguage`               | `string`                | `shell`     | The language of the code snippet for syntax highlighting.             |
+| `lightTheme`                 | `string`                | `min-light` | The theme to use for syntax highlighting in light mode.               |
+| `darkTheme`                  | `string`                | `min-dark`  | The theme to use for syntax highlighting in dark mode.                |
+| `theme`                      | `'light' \| 'dark'`     | `dark`      | The color theme to use for the component.                             |
+
+#### Usage
+
+```vue [MyComponent.vue]
+<ScriptCopy
+  :command-map="{
+    npm: 'npm run shadcn add button',
+    yarn: 'yarn shadcn add button',
+    pnpm: 'pnpm dlx shadcn@latest add button',
+    bun: 'bun x shadcn@latest add button',
+  }"
+/>
+```
+
+::
+
+## Component Code
+
+You can copy and paste the following code to create these components:
+
+::CodeViewer{filename="ScriptCopy.vue" language="vue" componentName="ScriptCopy" type="ui" id="script-copy"}
+::
+
+### Warning
+
+This component uses `v-html` to render syntax-highlighted code snippets. While this is necessary for the syntax highlighting functionality, be cautious as `v-html` can expose your application to XSS attacks if used with untrusted content. Make sure you only pass trusted command strings to the `commandMap` prop.
+
+### Available Themes
+
+Check out the complete list of available themes at [shiki.style/themes](https://shiki.style/themes).
+
+## Credits
+
+- Inspired by [Magic UI](https://magicui.design/docs/components/script-copy-btn).
+- Credit to [kalix127](https://github.com/kalix127) for porting this component.


### PR DESCRIPTION
This is a new component. Design From [Script Copy Button - MagicUI](https://magicui.design/docs/components/script-copy-btn)

https://github.com/user-attachments/assets/886d3a3d-188d-4fce-a905-1bcef796c28f

