### PR TITLE
fix: update deprecated husky command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx lint-staged
+pnpm dlx lint-staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:fix": "prettier . --write",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@nuxt/image": "^1.8.1",


### PR DESCRIPTION
Fixing this annoying warning for husky:
```
husky - install command is DEPRECATED
```

