### PR TITLE
docs: update installation guide to remove typescript from the tailwind configuration

### DIFF
--- a/content/1.getting-started/2.installation.md
+++ b/content/1.getting-started/2.installation.md
@@ -66,14 +66,13 @@ yarn add @vueuse/core @vueuse/motion
 
 Follow this guide to setup @vueuse/motion on [Vue](https://motion.vueuse.org/getting-started/introduction) and [Nuxt](https://motion.vueuse.org/getting-started/nuxt)
 
-### Update `tailwind.config.ts` and `tailwind.css`
+### Update `tailwind.config.js` and `tailwind.css`
 
-Add the following code to your `tailwind.config.ts` and your `css` file:
+Add the following code to your `tailwind.config.js` and your `css` file:
 
 ::code-group
 
-```ts [tailwind.config.ts]
-import type { Config } from "tailwindcss";
+```ts [tailwind.config.js]
 import animate from "tailwindcss-animate";
 import { setupInspiraUI } from "@inspira-ui/plugins";
 
@@ -129,7 +128,7 @@ export default {
   },
 
   plugins: [animate, setupInspiraUI],
-} satisfies Config;
+};
 ```
 
 ```css [tailwind.css]


### PR DESCRIPTION
With the old documentation, every project that followed the guide will show this annoying warning:
```
```