### PR TITLE
fix(LogoOrigami.vue): maybe don't use TransitionGroup?

### DIFF
--- a/components/content/inspira/ui/logo-origami/LogoOrigami.vue
+++ b/components/content/inspira/ui/logo-origami/LogoOrigami.vue
@@ -35,73 +35,71 @@
       <component :is="children[activeIndex % children.length]" />
     </div>
 
-    <TransitionGroup>
-      <!-- Upper part of the flip -->
-      <div
-        :key="activeIndex"
-        v-motion
-        :style="{
-          clipPath: 'polygon(0 0, 100% 0, 100% 50%, 0 50%)',
-          zIndex: -activeIndex,
-          backfaceVisibility: 'hidden',
-        }"
-        :initial="{
-          rotateX: '0deg',
-          y: '-50%',
-          x: '-50%',
-        }"
-        :enter="{
-          rotateX: '-180deg',
-          transition: {
-            duration: duration * 1000,
-            ease: 'easeInOut',
-          },
-        }"
-        :leave="{
-          rotateX: '-180deg',
-          transition: {
-            duration: duration * 1000,
-            ease: 'easeInOut',
-          },
-        }"
-        class="absolute left-1/2 top-1/2"
-      >
-        <component :is="children[activeIndex % children.length]" />
-      </div>
+    <!-- Upper part of the flip -->
+    <div
+      :key="activeIndex"
+      v-motion
+      :style="{
+        clipPath: 'polygon(0 0, 100% 0, 100% 50%, 0 50%)',
+        zIndex: -activeIndex,
+        backfaceVisibility: 'hidden',
+      }"
+      :initial="{
+        rotateX: '0deg',
+        y: '-50%',
+        x: '-50%',
+      }"
+      :enter="{
+        rotateX: '-180deg',
+        transition: {
+          duration: duration * 1000,
+          ease: 'easeInOut',
+        },
+      }"
+      :leave="{
+        rotateX: '-180deg',
+        transition: {
+          duration: duration * 1000,
+          ease: 'easeInOut',
+        },
+      }"
+      class="absolute left-1/2 top-1/2"
+    >
+      <component :is="children[activeIndex % children.length]" />
+    </div>
 
-      <!-- Lower part of the flip  -->
-      <div
-        :key="(activeIndex + 1) * 2"
-        v-motion
-        :style="{
-          clipPath: 'polygon(0 50%, 100% 50%, 100% 100%, 0 100%)',
-          zIndex: activeIndex,
-          backfaceVisibility: 'hidden',
-        }"
-        :initial="{
-          rotateX: '180deg',
-          y: '-50%',
-          x: '-50%',
-        }"
-        :enter="{
-          rotateX: '0deg',
-          transition: {
-            duration: duration * 1000,
-            ease: 'easeInOut',
-          },
-        }"
-        :leave="{
-          rotateX: '0deg',
-          transition: {
-            duration: duration * 1000,
-            ease: 'easeInOut',
-          },
-        }"
-        class="absolute left-1/2 top-1/2"
-      >
-        <component :is="children[(activeIndex + 1) % children.length]" />
-      </div>
-    </TransitionGroup>
+    <!-- Lower part of the flip  -->
+    <div
+      :key="(activeIndex + 1) * 2"
+      v-motion
+      :style="{
+        clipPath: 'polygon(0 50%, 100% 50%, 100% 100%, 0 100%)',
+        zIndex: activeIndex,
+        backfaceVisibility: 'hidden',
+      }"
+      :initial="{
+        rotateX: '180deg',
+        y: '-50%',
+        x: '-50%',
+      }"
+      :enter="{
+        rotateX: '0deg',
+        transition: {
+          duration: duration * 1000,
+          ease: 'easeInOut',
+        },
+      }"
+      :leave="{
+        rotateX: '0deg',
+        transition: {
+          duration: duration * 1000,
+          ease: 'easeInOut',
+        },
+      }"
+      class="absolute left-1/2 top-1/2"
+    >
+      <component :is="children[(activeIndex + 1) % children.length]" />
+    </div>
 
     <!-- Center divider line -->
     <hr


### PR DESCRIPTION
LogoOrigami component in browser, animation is break.Maybe dont't use TransitionGroup?

before:

https://github.com/user-attachments/assets/5ec35224-3481-4e4e-b9fc-01a8ffc98f54


after: 

https://github.com/user-attachments/assets/5136992e-5b44-4eb7-b5e3-3ad52f7028aa

