### PR TITLE
docs: fix content attribute in tailwind.config.js

### DIFF
--- a/content/1.getting-started/2.installation.md
+++ b/content/1.getting-started/2.installation.md
@@ -84,7 +84,7 @@ export default {
   darkMode: "selector",
   safelist: ["dark"],
   prefix: "",
-  content: [],
+  content: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx}",],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Fix the content attribute in the tailwind.config.js config file

Problem: The content attribute in the [doc](https://inspira-ui.com/getting-started/installation#update-tailwindconfigjs-and-tailwindcss) is empty, it will cause error during installation
![image](https://github.com/user-attachments/assets/60206e0a-585d-49b2-b3a0-9c48aa4f6b31)