### PR TITLE
Fix bun CLI

### DIFF
--- a/components/content/common/InstallationCli.vue
+++ b/components/content/common/InstallationCli.vue
@@ -25,7 +25,7 @@ pnpm dlx shadcn-vue@latest add "${url}"
 \`\`\`
 
 \`\`\`bash [bun]
-bun dlx shadcn-vue@latest add "${url}"
+bunx shadcn-vue@latest add "${url}"
 \`\`\`
 
 \`\`\`bash [yarn]


### PR DESCRIPTION
For Bun, `dlx` is not supported. Use `bunx` or `bun x` instead.

Reference: https://bun.sh/docs/cli/bunx