### PR TITLE
fix(NumberTicker): Add reacting to prop.value changes

### DIFF
--- a/components/content/inspira/ui/number-ticker/NumberTicker.vue
+++ b/components/content/inspira/ui/number-ticker/NumberTicker.vue
@@ -54,13 +54,26 @@ const isInView = useElementVisibility(spanRef, {
   threshold: 0,
 });
 
+const hasBeenInView = ref(false);
+
 watch(
   isInView,
   (isVisible) => {
-    if (isVisible) {
+    if (isVisible && !hasBeenInView.value) {
+      hasBeenInView.value = true;
       transitionValue.value = props.direction === "down" ? 0 : props.value;
     }
   },
   { immediate: true },
+);
+
+
+watch(
+  () => props.value,
+  (newVal) => {
+    if (hasBeenInView.value) {
+      transitionValue.value = props.direction === 'down' ? 0 : newVal;
+    }
+  }
 );
 </script>


### PR DESCRIPTION
Added a new watch on `props.value` to update `transitionValue`, ensuring the value transitions correctly when the element has been in view and continues reactivity after initial load.

Test by changing 100 into any other number on `<NumberTicker :value="100" />`.