### PR TITLE
fix(T3NumberTicker): Added stopIsInViewWatcher for performance

### DIFF
--- a/components/content/inspira/ui/number-ticker/NumberTicker.vue
+++ b/components/content/inspira/ui/number-ticker/NumberTicker.vue
@@ -56,24 +56,24 @@ const isInView = useElementVisibility(spanRef, {
 
 const hasBeenInView = ref(false);
 
-watch(
+const stopIsInViewWatcher = watch(
   isInView,
   (isVisible) => {
     if (isVisible && !hasBeenInView.value) {
       hasBeenInView.value = true;
       transitionValue.value = props.direction === "down" ? 0 : props.value;
+      stopIsInViewWatcher();
     }
   },
   { immediate: true },
 );
 
-
 watch(
   () => props.value,
   (newVal) => {
     if (hasBeenInView.value) {
-      transitionValue.value = props.direction === 'down' ? 0 : newVal;
+      transitionValue.value = props.direction === "down" ? 0 : newVal;
     }
-  }
+  },
 );
 </script>


### PR DESCRIPTION
Tiny miss from my side that can increase performance a bit. Now the first watcher doesn’t rerun unnecessarily after being used for its purpose. 
Also fixed prettier format now, sorry 'bout that!