### PR TITLE
fix(CodeViewerTab): adjust positioning of CodeCopy component

### DIFF
--- a/components/content/common/CodeViewerTab.vue
+++ b/components/content/common/CodeViewerTab.vue
@@ -6,7 +6,7 @@
     :code="rawString"
   >
     <CodeCopy
-      class="absolute right-0 top-0"
+      class="absolute -top-10 right-0"
       :code="rawString"
     />
     <code class="min-w-full overflow-auto px-2 leading-4">


### PR DESCRIPTION
Before:
![overlap](https://github.com/user-attachments/assets/d5e32839-b8a0-4262-a2ab-d56923f5d349)

After:
![fix-overlap](https://github.com/user-attachments/assets/beaaa3c1-4e3a-44a4-b57d-a7c255c22a8f)
