### PR TITLE
Fixed keyboard event handling logic when the input box is empty.

### DIFF
--- a/components/content/inspira/ui/vanishing-input/VanishingInput.vue
+++ b/components/content/inspira/ui/vanishing-input/VanishingInput.vue
@@ -228,6 +228,7 @@ function animate(start: number = 0): void {
 }
 
 function handleKeyDown(e: KeyboardEvent): void {
+  if (vanishingText.value === "") return;
   if (e.key === "Enter" && !animating.value) {
     vanishAndSubmit();
   }


### PR DESCRIPTION
Before the repair, if you click the Enter key in the input box at [Placeholders And Vanish Input](https://inspira-ui.com/components/input-and-forms/placeholders-and-vanish-input) when the input value is empty, the focus of the input box will disappear and will not appear again no matter how you click. My modification solved this problem.
Before:

https://github.com/user-attachments/assets/2e3e34cc-b272-4381-9afb-aad7df4cfc23


After:

https://github.com/user-attachments/assets/b5aad598-8604-46b2-ad54-beefd3fd217b



