### PR TITLE
docs(ScrollIslandDemo): Modify the a tag in ScrollIsland to make it jump to the anchor point normally, and enhance document availability

### DIFF
--- a/components/content/inspira/examples/scroll-island/ScrollIslandDemo.vue
+++ b/components/content/inspira/examples/scroll-island/ScrollIslandDemo.vue
@@ -5,8 +5,9 @@
     </span>
     <ScrollIsland title="Scroll Island">
       <div class="my-3 flex flex-col gap-2">
+        <a href="#install-using-cli"># Install using CLI</a>
+        <a href="#install-manually"># Install Manually</a>
         <a href="#api"># API</a>
-        <a href="#component-code"># Component Code</a>
         <a href="#features"># Features</a>
         <a href="#credits"># Credits</a>
       </div>


### PR DESCRIPTION
Now, after the component at the top of the ScrollIsland page is clicked, the anchor link cannot jump normally. The reason is that the original href of the a tag is incorrectly written. Users may feel confused when browsing the web. Now this problem has been fixed. Users can jump normally in documents, which enhances the usability of the documents. 

**Code changes:**
before:
![image](https://github.com/user-attachments/assets/4bbd8d89-7f95-43fc-b9dc-0b60ce5fcd4b)
after:
![image](https://github.com/user-attachments/assets/fe069f46-eb02-4dda-970f-0afa42f73550)

**Documentation changes:**
before:

https://github.com/user-attachments/assets/8788cbd7-4434-4e9f-8b5e-aa2dd2ac49c4


after:

https://github.com/user-attachments/assets/cab1f8fa-3404-473f-a4f6-6a4bb7cba19e


