### PR TITLE
style(GlowBorder): Increase mouse event passthrough

### DIFF
--- a/components/content/inspira/ui/glow-border/GlowBorder.vue
+++ b/components/content/inspira/ui/glow-border/GlowBorder.vue
@@ -13,7 +13,7 @@
       :class="
         cn(
           `glow-border before:absolute before:inset-0 before:aspect-square before:size-full before:rounded-[--border-radius] before:bg-[length:300%_300%] before:p-[--border-width] before:opacity-50 before:will-change-[background-position] before:content-['']`,
-          'before:![-webkit-mask-composite:xor] before:![mask-composite:exclude] before:[mask:--mask-linear-gradient]',
+          'before:![-webkit-mask-composite:xor] before:![mask-composite:exclude] before:[mask:--mask-linear-gradient pointer-events-none]',
         )
       "
     ></div>


### PR DESCRIPTION
**Problem description:**
When using interactive components such as <input /> inside the <slot /> of the Glow Border component, event penetration does not work.

<img width="616" alt="image" src="https://github.com/user-attachments/assets/1f635a73-f8ec-4200-95cc-323d1ec90465" />


**Solution:**
Add the pointer-events-none attribute to the inner elements of the Glow Border component.

<img width="560" alt="image" src="https://github.com/user-attachments/assets/ec4d0ba7-7c29-4dde-86fd-b9326133f1e3" />
