### PR TITLE
fix(LogoOrigami): Fixed the flickering phenomenon of LogoOrigami when flipping

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,8 @@
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
     "**/node_modules/*/**": true
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/components/content/inspira/ui/logo-origami/LogoOrigami.vue
+++ b/components/content/inspira/ui/logo-origami/LogoOrigami.vue
@@ -15,7 +15,7 @@
     <div
       :style="{
         clipPath: 'polygon(0 0, 100% 0, 100% 50%, 0 50%)',
-        zIndex: -1,
+        zIndex: -999,
         backfaceVisibility: 'hidden',
       }"
       class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
@@ -27,7 +27,7 @@
     <div
       :style="{
         clipPath: 'polygon(0 50%, 100% 50%, 100% 100%, 0 100%)',
-        zIndex: -1,
+        zIndex: -999,
         backfaceVisibility: 'hidden',
       }"
       class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"


### PR DESCRIPTION
Because the zindex of the two static parts is not small enough, flickering occurs. Now I fixed it.
View comparison:
Before:

https://github.com/user-attachments/assets/d037cc64-85b9-4135-836c-04317be89532


After:

https://github.com/user-attachments/assets/308ae2eb-47d0-4719-b5f7-45626064b39f

