### PR TITLE
fix(MultiStepLoader): Background leads to poor reading experience

### DIFF
--- a/components/content/inspira/ui/multi-step-loader/MultiStepLoader.vue
+++ b/components/content/inspira/ui/multi-step-loader/MultiStepLoader.vue
@@ -135,7 +135,7 @@
         </div>
       </div>
       <div
-        class="absolute inset-x-0 bottom-0 z-20 h-full bg-white bg-gradient-to-t [mask-image:radial-gradient(900px_at_center,transparent_30%,white)] dark:bg-black"
+        class="absolute inset-x-0 bottom-0 z-[-1] h-full bg-white bg-gradient-to-t [mask-image:radial-gradient(900px_at_center,white_30%,transparent)] dark:bg-black"
       ></div>
     </div>
   </Transition>


### PR DESCRIPTION
Ensure that the content of the middle area is displayed normally and is not affected by the background, even if there is a protruding color on the back, it does not affect reading.

Before:
![image](https://github.com/user-attachments/assets/c23cf931-0535-4086-a691-2d66e61ea9ef)

After:
![image](https://github.com/user-attachments/assets/59116f34-eb1d-4e1d-b71f-b3dfef5e63a8)
