### PR TITLE
Fix Smooth Cursor component by importing proper VueUse functions

### DIFF
--- a/components/content/inspira/ui/smooth-cursor/SmoothCursor.vue
+++ b/components/content/inspira/ui/smooth-cursor/SmoothCursor.vue
@@ -29,6 +29,7 @@
 import type { Component } from "vue";
 import DefaultCursor from "./DefaultCursor.vue";
 import { useSpring, Motion } from "motion-v";
+import { useEventListener, useTimeout } from '@vueuse/core';
 
 interface Position {
   x: number;


### PR DESCRIPTION
The functions `useEventListener` and `useTimeout`, which are functions from the VueUse module, were not properly imported in the script of the Smooth Cursor component (`SmoothCursor.vue`). In Nuxt, the lack of `useEventListener` led to a 500 error, breaking the application. The lack of `useTimeout` caused the cursor to freeze up after the page fully loaded. To fix both of these issues, these functions were simply imported from @vueuse/core with the following, one-line change:

```vue
<script lang="ts" setup>
          //...
     import { useEventListener, useTimeout } from '@vueuse/core';
          //...
</script>
``` 