### PR TITLE
fix: allow Lens to works without `hovering` ref

### DIFF
--- a/components/content/inspira/ui/lens/Lens.vue
+++ b/components/content/inspira/ui/lens/Lens.vue
@@ -54,6 +54,7 @@ const props = withDefaults(defineProps<LensProps>(), {
   zoomFactor: 1.5,
   lensSize: 170,
   isStatic: false,
+  hovering: undefined,
   position: () => ({ x: 200, y: 150 }),
 });
 


### PR DESCRIPTION
In latest version of Vue/Nuxt, `props.hovering` is automatically defaults to `false` instead of `undefined`, which means it won't work without needing the user to pass in their own `hovering` ref, this adjustment makes sure it should be defaults to `undefined` and allow it to work with `localIsHovering`