### PR TITLE
Add separate link to the tailwind install guide for Nuxt

### DIFF
--- a/content/1.getting-started/2.installation.md
+++ b/content/1.getting-started/2.installation.md
@@ -40,7 +40,7 @@ Follow this guide to setup `motion-v` on [Vue or Nuxt](https://motion.dev/docs/v
 
 ### Set up `tailwindcss`
 
-To begin, install `tailwindcss` using [this guide](https://tailwindcss.com/docs/installation).
+To begin, install `tailwindcss` using this [Vite install guide for Vue](https://tailwindcss.com/docs/installation) or using this [framework-specific guide for Nuxt](https://tailwindcss.com/docs/installation/framework-guides/nuxt).
 
 ### Add dependencies
 


### PR DESCRIPTION
Tailwindcss.com has an install guide specific for Nuxt so it's nice to have that direct link, as it shows the details of the required configuration in `nuxt.config.ts`.