### PR TITLE
fix(docs): adjust CodeCopy component positioning

### DIFF
--- a/components/content/common/CodeViewerTab.vue
+++ b/components/content/common/CodeViewerTab.vue
@@ -6,7 +6,7 @@
     :code="rawString"
   >
     <CodeCopy
-      class="absolute -top-10 right-0"
+      class="absolute -top-12.5 right-0"
       :code="rawString"
     />
     <code class="min-w-full overflow-auto px-2 leading-4">


### PR DESCRIPTION
At the moment, `CodeCopy` button is not aligned vertically.

Making it `-top-12.5` instead of `-top-10` fixes this problem.