### PR TITLE
css(fix): Fixed an issue where overflow scroll was showing on componentTabs

### DIFF
--- a/app/components/common/component-viewer/ComponentTabs.vue
+++ b/app/components/common/component-viewer/ComponentTabs.vue
@@ -131,7 +131,7 @@ onMounted(() => {
     :items="items"
     class="min-h-[60vh] w-full"
     :ui="{
-      list: 'w-fit max-sm:w-full bg-transparent gap-4 self-start overflow-scroll',
+      list: 'w-fit max-sm:w-full bg-transparent gap-4 self-start overflow-auto',
       trigger: 'w-fit outline outline-neutral-200 dark:outline-neutral-800',
       content: 'py-4',
     }"


### PR DESCRIPTION
Fixed an issue where overflow scroll was showing on componentTabs
<img width="717" height="444" alt="image" src="https://github.com/user-attachments/assets/6bd127e0-a138-48c3-802d-adb9dc17bdd2" />
