### PR TITLE
fix: Fix docs sidebar auto-scroll to active item + restore ShaderToy demo preview

### DIFF
--- a/app/components/docs/DocsAsideLeftBody.vue
+++ b/app/components/docs/DocsAsideLeftBody.vue
@@ -4,11 +4,86 @@ import type { ContentNavigationItem } from "@nuxt/content";
 const navigation = inject<Ref<ContentNavigationItem[]>>("navigation");
 
 const { nav } = useNavigation(navigation);
+
+const route = useRoute();
+const navContainer = ref<HTMLElement | null>(null);
+
+type NavItemWithData = ContentNavigationItem & {
+  "data-nav-path"?: string;
+  children?: NavItemWithData[];
+};
+
+function addDataNavPath(items: ContentNavigationItem[] = []): NavItemWithData[] {
+  return items.map((item) => ({
+    ...item,
+    "data-nav-path": item.path,
+    children: item.children ? addDataNavPath(item.children) : item.children,
+  }));
+}
+
+const navWithData = computed(() => addDataNavPath(nav.value));
+
+async function scrollActiveLinkIntoView() {
+  await nextTick();
+
+  const escapedPath = typeof CSS !== "undefined" && CSS.escape ? CSS.escape(route.path) : route.path;
+  const activeItem = navContainer.value?.querySelector<HTMLElement>(
+    `[data-nav-path="${escapedPath}"], [data-nav-path="${escapedPath}/"]`,
+  );
+
+  if (!activeItem) {
+    return;
+  }
+
+  const scrollParent = getScrollParent(activeItem);
+  if (!scrollParent) {
+    activeItem.scrollIntoView({ block: "center", inline: "nearest" });
+    return;
+  }
+
+  const parentRect = scrollParent.getBoundingClientRect();
+  const itemRect = activeItem.getBoundingClientRect();
+
+  const itemOffsetTop = itemRect.top - parentRect.top;
+  const itemCenterOffset = itemOffsetTop + itemRect.height / 2;
+
+  // Prefer centering; if the container is too small, bias towards the upper half.
+  const desiredCenter = Math.max(scrollParent.clientHeight / 2, scrollParent.clientHeight * 0.35);
+  const targetScrollTop = scrollParent.scrollTop + (itemCenterOffset - desiredCenter);
+
+  const maxScrollTop = scrollParent.scrollHeight - scrollParent.clientHeight;
+  const clampedScrollTop = Math.min(Math.max(0, targetScrollTop), Math.max(0, maxScrollTop));
+
+  scrollParent.scrollTo({ top: clampedScrollTop, behavior: "auto" });
+}
+
+function getScrollParent(element: HTMLElement): HTMLElement | null {
+  let current: HTMLElement | null = element.parentElement;
+  while (current) {
+    const style = getComputedStyle(current);
+    const overflowY = style.overflowY;
+    const canScrollY = (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") &&
+      current.scrollHeight > current.clientHeight;
+    if (canScrollY) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+onMounted(scrollActiveLinkIntoView);
+
+watch(() => route.path, scrollActiveLinkIntoView);
+watch(navWithData, scrollActiveLinkIntoView, { deep: true });
 </script>
 
 <template>
-  <UContentNavigation
-    highlight
-    :navigation="nav"
-  />
+  <div ref="navContainer">
+    <UContentNavigation
+      highlight
+      :navigation="navWithData"
+    />
+  </div>
 </template>

--- a/app/components/inspira/ui/glowing-effect/GlowingEffect.vue
+++ b/app/components/inspira/ui/glowing-effect/GlowingEffect.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from "vue";
 import { animate } from "motion-v";
+import { cn } from "~/lib/utils";
 
 interface Props {
   blur?: number;

--- a/content/cn/2.components/miscellaneous/shader-toy.md
+++ b/content/cn/2.components/miscellaneous/shader-toy.md
@@ -5,7 +5,7 @@ category: 杂项
 tags: [css, tailwind, shader-toy, ogl, webgl]
 ---
 
-::ComponentViewer{demoFile="ShaderToyDemo.vue" config="AnimatedCircularProgressBarConfig" componentId="animated-circular-progressbar" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
+::ComponentViewer{demoFile="ShaderToyDemo.vue" config="ShaderToyConfig" componentId="shader-toy" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
 
 #api
 

--- a/content/en/2.components/miscellaneous/shader-toy.md
+++ b/content/en/2.components/miscellaneous/shader-toy.md
@@ -5,7 +5,7 @@ category: Miscellaneous
 tags: [css, tailwind, shader-toy, ogl, webgl]
 ---
 
-::ComponentViewer{demoFile="ShaderToyDemo.vue" config="AnimatedCircularProgressBarConfig" componentId="animated-circular-progressbar" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
+::ComponentViewer{demoFile="ShaderToyDemo.vue" config="ShaderToyConfig" componentId="shader-toy" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
 
 #api
 

--- a/content/fr/2.components/miscellaneous/shader-toy.md
+++ b/content/fr/2.components/miscellaneous/shader-toy.md
@@ -5,7 +5,7 @@ category: Divers
 tags: [css, tailwind, shader-toy, ogl, webgl]
 ---
 
-::ComponentViewer{demoFile="ShaderToyDemo.vue" config="AnimatedCircularProgressBarConfig" componentId="animated-circular-progressbar" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
+::ComponentViewer{demoFile="ShaderToyDemo.vue" config="ShaderToyConfig" componentId="shader-toy" :componentFiles='["ShaderToy.vue", "InspiraShaderToy.ts"]' dependencies="ogl"}
 
 #api
 


### PR DESCRIPTION
## Changes

- **Docs sidebar**: Auto-scroll the left navigation to the active route on load/navigation, keeping the active item near the middle (or upper half) for better visibility.
- **Shader Toy Viewer docs**: Fix `ComponentViewer` `config`/`componentId` so the demo preview renders correctly in `en`, `cn`, and `fr`.
- **GlowingEffect**: Enhance the display of the glow effect component.

## Screenshot

**Docs sidebar active-item positioning**

![Docs sidebar active-item positioning](https://github.com/user-attachments/assets/cf442ea0-6870-4b0b-a7d8-c4df9253c5bb)

**Docs sidebar**

![Snipaste_2025-12-30_00-33-32](https://github.com/user-attachments/assets/33f5969b-2b3b-43b1-b28a-7d2ed2890a89)
