### PR TITLE
fix: HaloSearch autofill style

### DIFF
--- a/app/components/inspira/ui/halo-search/HaloSearch.vue
+++ b/app/components/inspira/ui/halo-search/HaloSearch.vue
@@ -88,6 +88,12 @@ const props = defineProps<Props>();
   outline: none;
 }
 
+.search-field:autofill {
+  box-shadow: 0 0 0 1000px #010201 inset;
+  -webkit-text-fill-color: white;
+  caret-color: white;
+}
+
 .inner-glow,
 .main-border,
 .outer-ring,


### PR DESCRIPTION
When there is autofill content in the search box, selecting an entry from the history or after selecting one will turn the background color gray, which looks a bit ugly.
<img width="460" height="386" alt="image" src="https://github.com/user-attachments/assets/981ca32c-a496-432a-9c22-60d259353ae2" />
<img width="496" height="190" alt="image" src="https://github.com/user-attachments/assets/cefdc521-d260-44b2-8b97-3232a9ee91cc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of autofilled text in search input fields to ensure white text and cursor display correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->