### PR TITLE
fix: properly remove scroll listener in tracing beam

### DIFF
--- a/app/components/inspira/ui/tracing-beam/TracingBeam.vue
+++ b/app/components/inspira/ui/tracing-beam/TracingBeam.vue
@@ -67,7 +67,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  tracingBeamRef.value?.removeEventListener("scroll", updateScrollYProgress);
+  window.removeEventListener("scroll", updateScrollYProgress);
   window.removeEventListener("resize", updateScrollYProgress);
 });
 


### PR DESCRIPTION
In `onMounted`, the `scroll` event is bound to `window`, so in `onUnmounted` it should also be removed from `window`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll event listener cleanup to prevent potential memory leaks and ensure proper resource management during component unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->