### PR TITLE
docs: fix typo in social media title

### DIFF
--- a/app/components/common/landing/JoinTheCommunity.vue
+++ b/app/components/common/landing/JoinTheCommunity.vue
@@ -9,7 +9,7 @@ const links = [
   },
   {
     icon: "tabler:brand-x",
-    title: "X (Formely Twitter)",
+    title: "X (Formerly Twitter)",
     description: "Follow for updates and sneak peeks.",
     to: `https://x.com/rahulv_dev`,
     target: "_blank",


### PR DESCRIPTION
Fixed a typo in the social media title.

Changed:
<img width="2560" height="1300" alt="image" src="https://github.com/user-attachments/assets/fa692d1f-43dd-47d3-8392-ebce32a8bf23" />

X ([Formely Twitter](https://inspira-ui.com/docs/en))
to:
X (formerly Twitter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in the social media links section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/inspira-ui/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->