### PR TITLE
docs: clarify color picker controlled usage

### DIFF
--- a/app/components/inspira/examples/color-picker/ColorPickerDemo.vue
+++ b/app/components/inspira/examples/color-picker/ColorPickerDemo.vue
@@ -9,6 +9,7 @@ const color = ref<ColorPickerValue>({
   rgb: { r: 163, g: 95, b: 255, a: 1 },
   rgba: { r: 163, g: 95, b: 255, a: 1 },
 });
+const isOpen = ref(false);
 
 function setColor(newColor: ColorPickerValue) {
   color.value = newColor;
@@ -20,11 +21,16 @@ function setColor(newColor: ColorPickerValue) {
     <div class="flex items-center justify-center">
       <ColorPicker
         :value="color.hsl"
+        v-model:open="isOpen"
         type="hsla"
         :swatches="['#AEDEAE', '#FFD3B6', '#FFB6B9', '#FFC0CB', '#FFD1DC']"
         @value-change="setColor"
       >
         <button
+          type="button"
+          aria-haspopup="dialog"
+          :aria-expanded="isOpen"
+          aria-label="Open color picker"
           class="ring-offset-background focus-visible:ring-ring border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-10 items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
         >
           <div

--- a/app/components/inspira/examples/color-picker/ColorPickerDemo.vue
+++ b/app/components/inspira/examples/color-picker/ColorPickerDemo.vue
@@ -30,7 +30,7 @@ function setColor(newColor: ColorPickerValue) {
           type="button"
           aria-haspopup="dialog"
           :aria-expanded="isOpen"
-          aria-label="Open color picker"
+          :aria-label="isOpen ? 'Close color picker' : 'Open color picker'"
           class="ring-offset-background focus-visible:ring-ring border-input bg-background hover:bg-accent hover:text-accent-foreground inline-flex h-10 items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
         >
           <div

--- a/content/en/2.components/input-and-forms/color-picker.md
+++ b/content/en/2.components/input-and-forms/color-picker.md
@@ -21,7 +21,7 @@ tags: [css, tailwind, input, color-picker, uplusion23]
 | `hideContrastRatio`   | `boolean`                                       | `false`     | Hide the accessibility contrast ratio section     |
 | `hideDefaultSwatches` | `boolean`                                       | `false`     | Hide the default color swatches                   |
 | `class`               | `string`                                        | `""`        | Additional CSS classes for the popover content    |
-| `open`                | `boolean`                                       | `false`     | Control the open/closed state of the color picker |
+| `open`                | `boolean`                                       | `false`     | Control the popover state with `v-model:open`     |
 
 ### ColorPicker Events
 
@@ -40,6 +40,48 @@ interface ColorPickerValue {
   rgb: RgbaColor; // RGB color object with r, g, b, a properties
   rgba: RgbaColor; // RGBA color object with r, g, b, a properties
 }
+```
+
+### Controlled Usage
+
+Use `v-model:open` when the trigger needs to reflect or manage the popover state. The picker accepts hex, HSVA, HSLA, and RGBA inputs through `value`, then emits a normalized `ColorPickerValue` object from `value-change`.
+
+```vue
+<script setup lang="ts">
+import type { ColorPickerValue } from "@/components/content/inspira/ui/color-picker";
+import { ref } from "vue";
+
+const isOpen = ref(false);
+const color = ref<ColorPickerValue>({
+  hex: "#A35fFF",
+  hsl: { h: 265.5, s: 100, l: 67, a: 1 },
+  hsla: { h: 265.5, s: 100, l: 67, a: 1 },
+  rgb: { r: 163, g: 95, b: 255, a: 1 },
+  rgba: { r: 163, g: 95, b: 255, a: 1 },
+});
+
+function setColor(newColor: ColorPickerValue) {
+  color.value = newColor;
+}
+</script>
+
+<template>
+  <ColorPicker
+    :value="color.hsl"
+    v-model:open="isOpen"
+    type="hsla"
+    :swatches="['#AEDEAE', '#FFD3B6', '#FFB6B9']"
+    @value-change="setColor"
+  >
+    <button
+      type="button"
+      aria-haspopup="dialog"
+      :aria-expanded="isOpen"
+    >
+      Pick Color
+    </button>
+  </ColorPicker>
+</template>
 ```
 
 #credits


### PR DESCRIPTION
## Summary

- Clarifies that the `open` prop can be controlled with `v-model:open`.
- Adds a controlled usage example for `ColorPicker` that shows how to keep the trigger state in sync with the popover.
- Updates the demo trigger with `type="button"`, `aria-haspopup`, `aria-expanded`, and an accessible label.

## Why

The `ColorPicker` API already supports controlled popover state through `open` and `update:open`, but the docs did not show how to wire this up in a typical Vue usage pattern.

This adds a small example that makes the API behavior easier to discover and improves the demo trigger semantics.

## Testing

- Ran `git diff --check`.
- Did not run the full Nuxt app locally because `pnpm` is not available in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Color Picker now supports a controlled open-state via v-model:open for explicit open/close control.
  * Trigger button accessibility improved: ARIA attributes now reflect the picker's open/closed state.

* **Documentation**
  * Updated Color Picker docs with a "Controlled Usage" example and clearer prop descriptions, including usage and event handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unovue/inspira-ui/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->