### PR TITLE
i18n(ko): complete missing toc.* Korean translation keys

### DIFF
--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -18,5 +18,15 @@
     "toc": "이 페이지에서",
     "report": "문제 신고",
     "edit": "이 페이지 편집"
+  },
+
+  "toc": {
+    "title": "이 페이지에서",
+    "StarOnGitHub": "GitHub에서 Star 주기",
+    "CreateIssues": "이슈 만들기",
+    "JoinDiscord": "Discord 참여하기",
+    "Forum": "포럼",
+    "FollowOnX": "X에서 팔로우하기",
+    "FollowOnBluesky": "Bluesky에서 팔로우하기"
   }
 }


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- `i18n/locales/ko.json`: added the missing `toc` section (7 leaf keys: `title`,
  `StarOnGitHub`, `CreateIssues`, `JoinDiscord`, `Forum`, `FollowOnX`,
  `FollowOnBluesky`) that existed in `en.json` but was absent from `ko.json`.
  No existing keys were changed.

## Testing

- Verified `ko.json` is valid JSON.
- Programmatically compared the flattened leaf-key sets of `en.json` and
  `ko.json`: they now match exactly (19/19 keys), with no missing and no
  extra keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Korean translations for the table of contents area.
  * Included localized labels for community and social actions such as GitHub, issues, Discord, forum, X, and Bluesky.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->